### PR TITLE
new favicon

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -45,9 +45,13 @@ export const metadata: Metadata = {
     follow: true,
   },
   icons: {
-    icon: "/icon.svg",
+    icon: [
+      { url: "/icon.svg", type: "image/svg+xml" },
+    ],
     shortcut: "/icon.svg",
-    apple: "/icon.svg",
+    apple: [
+      { url: "/icon.svg", sizes: "180x180", type: "image/svg+xml" },
+    ],
   },
 };
 

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -15,6 +15,19 @@ export default function manifest(): MetadataRoute.Manifest {
         src: "/icon.svg",
         sizes: "any",
         type: "image/svg+xml",
+        purpose: "any maskable",
+      },
+      {
+        src: "/icon.svg",
+        sizes: "192x192",
+        type: "image/svg+xml",
+        purpose: "any",
+      },
+      {
+        src: "/icon.svg",
+        sizes: "512x512",
+        type: "image/svg+xml",
+        purpose: "any",
       },
     ],
   };

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="6" fill="#0ea5e9"/>
+  <path d="M16 6L8 10M16 6L24 10M16 6V14M8 10V18L16 22M8 10L16 14M24 10V18L16 22M24 10L16 14M16 22V14" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an SVG favicon and updates Next.js metadata and PWA manifest with multi-size and maskable icons.
> 
> - **Assets**:
>   - Add `public/icon.svg`.
> - **Metadata (Next.js)**:
>   - Update `app/layout.tsx` `icons` to arrays; configure `icon` and `apple` entries to use SVG.
> - **PWA Manifest**:
>   - Expand `app/manifest.ts` `icons` with maskable support and explicit `192x192` and `512x512` SVG entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89199b9a9fd4c513393afa0d76c36d1814d9b29d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->